### PR TITLE
11-CORE: GET /api/articles (sorting queries)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -636,3 +636,60 @@ describe('GET /api/users', () => {
       });
   });
 });
+
+describe('GET /api/articles (sorting queries)', () => {
+  test('200: Sorts articles by a valid column in descending order by default', () => {
+    return request(app)
+      .get('/api/articles?sort_by=votes')
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy('votes', { descending: true });
+      });
+  });
+
+  test('200: Sorts articles in ascending order when order=asc', () => {
+    return request(app)
+      .get('/api/articles?sort_by=created_at&order=asc')
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy('created_at', { ascending: true });
+      });
+  });
+
+  test('400: Responds with an error if sort_by column is invalid', () => {
+    return request(app)
+      .get('/api/articles?sort_by=invalid_column')
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Invalid sort_by column: invalid_column');
+      });
+  });
+
+  test('400: Responds with an error if order is invalid', () => {
+    return request(app)
+      .get('/api/articles?sort_by=created_at&order=random')
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Invalid order: random. Must be 'asc' or 'desc'");
+      });
+  });
+
+  test('200: Responds with default sorting by created_at in descending order if no query params are provided', () => {
+    return request(app)
+      .get('/api/articles')
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy('created_at', { descending: true });
+      });
+  });
+
+  test('200: Ignores unexpected query parameters and still returns articles', () => {
+    return request(app)
+      .get('/api/articles?sort_by=created_at&order=asc&unexpected_param=value')
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(Array.isArray(articles)).toBe(true);
+        expect(articles).toBeSortedBy('created_at', { ascending: true });
+      });
+  });
+});

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -17,7 +17,16 @@ function selectArticleById({ article_id }) {
 }
 
 function selectArticles({ sort_by = 'created_at', order = 'desc' }) {
-  const validSortColumns = ['created_at'];
+  const validSortColumns = [
+    'author',
+    'title',
+    'article_id',
+    'topic',
+    'created_at',
+    'votes',
+    'article_img_url',
+    'comment_count',
+  ];
   const validOrders = ['asc', 'desc'];
   let sql = `SELECT 
       articles.author,
@@ -39,7 +48,7 @@ function selectArticles({ sort_by = 'created_at', order = 'desc' }) {
     });
   }
 
-  if (!validOrders.includes(order)) {
+  if (!validOrders.includes(order.toLowerCase())) {
     return Promise.reject({
       msg: `Invalid order: ${order}. Must be 'asc' or 'desc'`,
       status: 400,


### PR DESCRIPTION
FEATURE REQUEST

The endpoint should also accept the following queries:

- sort_by, which sorts the articles by any valid column (defaults to the created_at date).
- order, which can be set to asc or desc for ascending or descending (defaults to descending).